### PR TITLE
Wrap compatibility load in a try-catch

### DIFF
--- a/src/main/kotlin/net/pdevita/creeperheal2/compatibility/CompatibilityManager.kt
+++ b/src/main/kotlin/net/pdevita/creeperheal2/compatibility/CompatibilityManager.kt
@@ -17,9 +17,13 @@ class CompatibilityManager(val plugin: CreeperHeal2) {
             val otherPlugin = Bukkit.getPluginManager().getPlugin(compatibilityPlugin.pluginName)
             if (otherPlugin != null) {
                 plugin.debugLogger("Loading compatibility for plugin ${compatibilityPlugin.pluginName}")
-                compatibilityPlugin.setPluginReference(otherPlugin)
-                compatibilityPlugin.setCreeperHealReference(plugin)
-                pluginList.add(compatibilityPlugin)
+                try {
+                    compatibilityPlugin.setPluginReference(otherPlugin)
+                    compatibilityPlugin.setCreeperHealReference(plugin)
+                    pluginList.add(compatibilityPlugin)
+                } catch (e: NoClassDefFoundError) {
+                    continue
+                }
             }
         }
     }


### PR DESCRIPTION
I'm not sure how kotlin-esk this PR is, but it does fix #20.

In an ideal world we'd check to make sure the class path is correct in addition to this, but that wasn't as simple.