### PR TITLE
Fix between-blocks-delay not working for values under 20 ticks

### DIFF
--- a/src/main/kotlin/net/pdevita/creeperheal2/core/Explosion.kt
+++ b/src/main/kotlin/net/pdevita/creeperheal2/core/Explosion.kt
@@ -429,7 +429,7 @@ class Explosion() {
                 // If we are cancelling, exit, otherwise, keep going
                 if (!cancelReplace.get()) {
                     delayJob = async(Dispatchers.async) {
-                        delay((plugin.settings.general.betweenBlocksDelay / 20 * 1000).toLong())
+                        delay((plugin.settings.general.betweenBlocksDelay / 20.0 * 1000).toLong())
                     }
                     delayJob!!.join()
                     // Delay is kinda long, could be good to check again
@@ -454,7 +454,7 @@ class Explosion() {
                 }
                 if (!cancelReplace.get()) {
                     delayJob = async(Dispatchers.async) {
-                        delay((plugin.settings.general.betweenBlocksDelay / 20 * 1000).toLong())
+                        delay((plugin.settings.general.betweenBlocksDelay / 20.0 * 1000).toLong())
                     }
                     delayJob!!.join()
                     // Delay is kinda long, could be good to check again

--- a/src/main/kotlin/net/pdevita/creeperheal2/core/Explosion.kt
+++ b/src/main/kotlin/net/pdevita/creeperheal2/core/Explosion.kt
@@ -429,7 +429,7 @@ class Explosion() {
                 // If we are cancelling, exit, otherwise, keep going
                 if (!cancelReplace.get()) {
                     delayJob = async(Dispatchers.async) {
-                        delay((plugin.settings.general.betweenBlocksDelay * 1000 / 20).toLong())
+                        delay((plugin.settings.general.betweenBlocksDelay * 50).toLong())
                     }
                     delayJob!!.join()
                     // Delay is kinda long, could be good to check again
@@ -454,7 +454,7 @@ class Explosion() {
                 }
                 if (!cancelReplace.get()) {
                     delayJob = async(Dispatchers.async) {
-                        delay((plugin.settings.general.betweenBlocksDelay * 1000 / 20).toLong())
+                        delay((plugin.settings.general.betweenBlocksDelay * 50).toLong())
                     }
                     delayJob!!.join()
                     // Delay is kinda long, could be good to check again

--- a/src/main/kotlin/net/pdevita/creeperheal2/core/Explosion.kt
+++ b/src/main/kotlin/net/pdevita/creeperheal2/core/Explosion.kt
@@ -429,7 +429,7 @@ class Explosion() {
                 // If we are cancelling, exit, otherwise, keep going
                 if (!cancelReplace.get()) {
                     delayJob = async(Dispatchers.async) {
-                        delay((plugin.settings.general.betweenBlocksDelay / 20.0 * 1000).toLong())
+                        delay((plugin.settings.general.betweenBlocksDelay * 1000 / 20).toLong())
                     }
                     delayJob!!.join()
                     // Delay is kinda long, could be good to check again
@@ -454,7 +454,7 @@ class Explosion() {
                 }
                 if (!cancelReplace.get()) {
                     delayJob = async(Dispatchers.async) {
-                        delay((plugin.settings.general.betweenBlocksDelay / 20.0 * 1000).toLong())
+                        delay((plugin.settings.general.betweenBlocksDelay * 1000 / 20).toLong())
                     }
                     delayJob!!.join()
                     // Delay is kinda long, could be good to check again


### PR DESCRIPTION
Hello, currently there is an issue where `between-blocks-delay` does not support values that are not multiples of 20, causing explosion block regeneration delays to be rounded down to the nearest second. This is because integer division does not support decimal values.

The fix is to simply skip the division and multiple the tick value by 50 to get the time in milliseconds. Hope this helps.