### PR TITLE
Add WeaponMechanics compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,10 @@
             <name>FactionsUUID repo</name>
             <url>https://ci.ender.zone/plugin/repository/everything/</url>
         </repository>
+        <repository>
+            <id>jeff-media-public</id>
+            <url>https://repo.jeff-media.com/public/</url>
+        </repository>
     </repositories>
     <dependencies>
         <dependency>
@@ -99,6 +103,18 @@
             <groupId>com.palmergames.bukkit.towny</groupId>
             <artifactId>towny</artifactId>
             <version>0.100.1.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.cjcrafter</groupId>
+            <artifactId>weaponmechanics</artifactId>
+            <version>4.1.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.cjcrafter</groupId>
+            <artifactId>mechanicscore</artifactId>
+            <version>4.1.0</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/kotlin/net/pdevita/creeperheal2/compatibility/WeaponMechanics.kt
+++ b/src/main/kotlin/net/pdevita/creeperheal2/compatibility/WeaponMechanics.kt
@@ -1,0 +1,48 @@
+package net.pdevita.creeperheal2.compatibility
+
+import com.google.auto.service.AutoService
+import net.pdevita.creeperheal2.CreeperHeal2
+import org.bukkit.Bukkit
+import org.bukkit.Location
+import org.bukkit.Material
+import org.bukkit.block.data.BlockData
+import org.bukkit.event.EventHandler
+import org.bukkit.event.EventPriority
+import org.bukkit.event.block.BlockBreakEvent
+
+
+@AutoService(BaseCompatibility::class)
+class WeaponMechanics : BaseCompatibility {
+    override val pluginName = "WeaponMechanics"
+    override val pluginPackage = "me.deecaad.weaponmechanics.WeaponMechanicsLoader"
+    private lateinit var creeperHeal2: CreeperHeal2
+
+    override fun setCreeperHealReference(creeperHeal2: CreeperHeal2) {
+        this.creeperHeal2 = creeperHeal2
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST)
+    fun onWeaponMechanicsBreakBlockEvent(event: BlockBreakEvent) {
+        if (event.eventName == "WeaponMechanicsBlockDamage") {
+            val loc = event.block.location.clone()
+            val originalMaterial = event.block.type
+            val originalData = event.block.blockData.clone()
+
+            Bukkit.getScheduler().runTaskLater(creeperHeal2, Runnable {
+                checkLocAndExplode(loc, originalMaterial, originalData)
+            }, 1)
+        }
+    }
+
+    fun checkLocAndExplode(loc: Location, originalMaterial: Material, originalData: BlockData) {
+        val block = loc.block
+        if (block.type == Material.AIR) {
+            if (loc.world?.let { creeperHeal2.settings.worldList.allowWorld(it.name) } == true) {
+                block.type = originalMaterial
+                block.blockData = originalData
+
+                creeperHeal2.createNewExplosion(listOf(block))
+            }
+        }
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -7,6 +7,7 @@ softdepend:
   - Movecraft
   - Factions
   - Towny
+  - WeaponMechanics
 
 commands:
   creeperheal:


### PR DESCRIPTION
This PR adds support for WeaponMechanics by conditionally registering a compatibility listener when the plugin is present. It restores blocks broken by guns.

This PR includes better code for WM compat than the previous ones I created.

One consideration that needs to be investigated is that it doesn't seem to build unless SpigotUpdateChecker is present (most likely due to WM requiring it).