### PR TITLE
Add option to drop all blacklisted items

### DIFF
--- a/src/main/kotlin/net/pdevita/creeperheal2/CreeperHeal2.kt
+++ b/src/main/kotlin/net/pdevita/creeperheal2/CreeperHeal2.kt
@@ -9,8 +9,10 @@ import net.pdevita.creeperheal2.core.ExplosionManager
 import net.pdevita.creeperheal2.core.Gravity
 import net.pdevita.creeperheal2.listeners.Explode
 import net.pdevita.creeperheal2.utils.Stats
+import org.bukkit.Material
 import org.bukkit.block.Block
 import org.bukkit.entity.Entity
+import org.bukkit.inventory.ItemStack
 import org.bukkit.plugin.java.JavaPlugin
 import java.io.File
 import java.util.*
@@ -68,7 +70,19 @@ class CreeperHeal2 : JavaPlugin() {
             return null
         }
 
-        val newBlockList = LinkedList(blockList.filter { settings.blockList.allowMaterial(it.type) })
+        val newBlockList = LinkedList<Block>()
+        for (block in blockList) {
+            if (settings.blockList.allowMaterial(block.type)) {
+                if (block.type != Material.BEDROCK && block.type != Material.AIR && block.type != Material.WATER) {
+                    newBlockList.add(block)
+                }
+            } else {
+                if (settings.general.dropBlacklisted) {
+                    block.breakNaturally()
+                    block.world.dropItemNaturally(block.location, ItemStack(block.type))
+                }
+            }
+        }
 
         if (newBlockList.isEmpty()) {
             return null

--- a/src/main/kotlin/net/pdevita/creeperheal2/config/ConfigManager.kt
+++ b/src/main/kotlin/net/pdevita/creeperheal2/config/ConfigManager.kt
@@ -40,6 +40,7 @@ class General(config: FileConfiguration) {
     val turboCap = config.getInt("turbo-cap", 10).coerceAtMost(1000)
     val entityType = config.getBoolean("entity-type", true)
     val disableContainers = config.getBoolean("disable-containers", false)
+    val dropBlacklisted = config.getBoolean("always-drop-blacklisted-items", false)
 }
 
 class ExplosionTypes(config: FileConfiguration) {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -24,6 +24,8 @@ disable-containers: false
 # Support entity-type blocks (Paintings, Item Frames, Armor Stands)
 entity-type: true
 
+always-drop-blacklisted-items: false
+
 # Turbo Mode
 # Turbo Mode can help repair larger explosions faster.
 # The minimum number of blocks an explosion should involve before turbo mode is activated


### PR DESCRIPTION
This PR adds a feature and a couple of related fixes.

- A config option has been made that allows all blacklisted blocks to be dropped if `always-drop-blacklisted-items` is true (false by default).
- It also fixes water and air being included in explosions which can sometimes cause duplicate blocks to drop or incorrect block regeneration.
- Bedrock blacklisting is also fixed (this is only an issue when WM is installed).